### PR TITLE
Add profile option to specify profile target

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ Use query parameter to profile a request:
 curl 'http://localhost:3000/slow-page?lineprof=active_support/core_ext/string'
 ```
 
+Or specify profile target by an option of `use`:
+```rb
+config.middleware.use Rack::Lineprof, profile: 'active_support/core_ext/string'
+```
+
 ![rack-lineprof screenshot](http://f.cl.ly/items/2q2r321e1j1X3X47303F/Screen%20Shot%202013-04-18%20at%209.58.36%20PM.png)
 
 

--- a/lib/rack/lineprof.rb
+++ b/lib/rack/lineprof.rb
@@ -20,7 +20,7 @@ module Rack
 
     def call env
       request = Rack::Request.new env
-      matcher = request.params['lineprof']
+      matcher = request.params['lineprof'] || options[:profile]
 
       return @app.call env unless matcher
 


### PR DESCRIPTION
When my profile target is fixed, adding the same query parameter bothers me.
So I added an `profile` option to choose profile target without query parameter.
### example

``` rb
config.middleware.use Rack::Lineprof, profile: 'active_support/core_ext/string'
```
