### PR TITLE
drop Gem::Specification#has_rdoc. it is deprecated with no replacement

### DIFF
--- a/rack-lineprof.gemspec
+++ b/rack-lineprof.gemspec
@@ -9,8 +9,6 @@ Gem::Specification.new do |s|
 
   s.files       = Dir['lib/**/*']
 
-  s.has_rdoc    = false
-
   s.authors     = ['Evan Owen']
   s.email       = %w[kainosnoema@gmail.com]
   s.homepage    = 'https://github.com/kainosnoema/rack-lineprof'


### PR DESCRIPTION
Gem::Specification#has_rdoc= was deprecated and ignored, at 1.3.3.

- https://blog.rubygems.org/2009/05/04/1.3.3-released.html

Deprecated Specification#has_rdoc was deprecated at 1.7.0.

- https://blog.rubygems.org/2011/03/28/1.7.0-released.html