### PR TITLE
Remove deprecated Gem::Specification#has_rdoc=

### DIFF
--- a/rack-lineprof.gemspec
+++ b/rack-lineprof.gemspec
@@ -9,8 +9,6 @@ Gem::Specification.new do |s|
 
   s.files       = Dir['lib/**/*']
 
-  s.has_rdoc    = false
-
   s.authors     = ['Evan Owen']
   s.email       = %w[kainosnoema@gmail.com]
   s.homepage    = 'https://github.com/kainosnoema/rack-lineprof'


### PR DESCRIPTION
`Gem::Specification#has_rdoc=` has been deprecated since 1.3.3  and should be removed. 

See https://blog.rubygems.org/2011/03/28/1.7.0-released.html for the deprecation notice, and https://blog.rubygems.org/2009/05/04/1.3.3-released.html for details.

```
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /Users/kawasy/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/bundler/gems/rack-lineprof-b625eb7e64ac/rack-lineprof.gemspec:12.
```