### PR TITLE
Print memory allocations

### DIFF
--- a/lib/rack/lineprof.rb
+++ b/lib/rack/lineprof.rb
@@ -29,8 +29,12 @@ module Rack
       response = nil
       profile = lineprof(%r{#{matcher}}) { response = @app.call env }
 
-      logger.debug Term::ANSIColor.blue("\n[Rack::Lineprof] #{'=' * 63}") + "\n\n" +
-           format_profile(profile) + "\n"
+      logger.debug(
+        Term::ANSIColor.blue("\n[Rack::Lineprof] #{'=' * 63}") +
+        Term::ANSIColor.blue("\n         ms     n   memory") +
+        "\n\n" +
+        format_profile(profile) + "\n"
+      )
 
       response
     end

--- a/lib/rack/lineprof/sample.rb
+++ b/lib/rack/lineprof/sample.rb
@@ -4,9 +4,9 @@ module Rack
 
       def format colorize = true
         formatted = if level == CONTEXT
-          sprintf "                          | % 3i  %s", line, code
+          sprintf "                        | % 3i  %s", line, code
         else
-          sprintf "% 6.1fms %5i (%10s) | % 3i  %s", ms, calls, line, allocations, code
+          sprintf "% 6.1fms %5i (%s) | % 3i  %s", ms, calls, line, allocations, code
         end
 
         return formatted unless colorize

--- a/lib/rack/lineprof/sample.rb
+++ b/lib/rack/lineprof/sample.rb
@@ -4,9 +4,9 @@ module Rack
 
       def format colorize = true
         formatted = if level == CONTEXT
-          sprintf "               | % 3i  %s", line, code
+          sprintf "                    | % 3i  %s", line, code
         else
-          sprintf "% 6.1fms %5i | % 3i  %s", ms, calls, line, "#{code} (#{allocations})"
+          sprintf "% 6.1fms %10s | % 3i  %s", ms, allocations, line, code
         end
 
         return formatted unless colorize

--- a/lib/rack/lineprof/sample.rb
+++ b/lib/rack/lineprof/sample.rb
@@ -6,7 +6,7 @@ module Rack
         formatted = if level == CONTEXT
           sprintf "               | % 3i  %s", line, code
         else
-          sprintf "% 6.1fms %5i | % 3i  %s", ms, calls, line, "#{code} (#{allocations} malloc)"
+          sprintf "% 6.1fms %5i | % 3i  %s", ms, calls, line, "#{code} (#{allocations})"
         end
 
         return formatted unless colorize

--- a/lib/rack/lineprof/sample.rb
+++ b/lib/rack/lineprof/sample.rb
@@ -4,9 +4,9 @@ module Rack
 
       def format colorize = true
         formatted = if level == CONTEXT
-          sprintf "                    | % 3i  %s", line, code
+          sprintf "                          | % 3i  %s", line, code
         else
-          sprintf "% 6.1fms %10s | % 3i  %s", ms, allocations, line, code
+          sprintf "% 6.1fms %5i (%10s) | % 3i  %s", ms, calls, line, allocations, code
         end
 
         return formatted unless colorize

--- a/lib/rack/lineprof/sample.rb
+++ b/lib/rack/lineprof/sample.rb
@@ -6,7 +6,7 @@ module Rack
         formatted = if level == CONTEXT
           sprintf "                        | % 3i  %s", line, code
         else
-          sprintf "% 6.1fms %5i (%s) | % 3i  %s", ms, calls, line, allocations, code
+          sprintf "% 6.1fms %5i (%s) | % 3i  %s", ms, calls, allocations, line, code
         end
 
         return formatted unless colorize

--- a/lib/rack/lineprof/sample.rb
+++ b/lib/rack/lineprof/sample.rb
@@ -4,9 +4,9 @@ module Rack
 
       def format colorize = true
         formatted = if level == CONTEXT
-          sprintf "                        | % 3i  %s", line, code
+          sprintf "                          | % 3i  %s", line, code
         else
-          sprintf "% 6.1fms %5i (%s) | % 3i  %s", ms, calls, allocations, line, code
+          sprintf "% 6.1fms %5i (%8s) | % 3i  %s", ms, calls, allocations, line, code
         end
 
         return formatted unless colorize

--- a/lib/rack/lineprof/sample.rb
+++ b/lib/rack/lineprof/sample.rb
@@ -6,7 +6,7 @@ module Rack
         formatted = if level == CONTEXT
           sprintf "               | % 3i  %s", line, code
         else
-          sprintf "% 6.1fms %5i | % 3i  %s (%s malloc)", ms, calls, line, code, allocations
+          sprintf "% 6.1fms %5i | % 3i  %s", ms, calls, line, "#{code} (#{allocations} malloc)"
         end
 
         return formatted unless colorize

--- a/lib/rack/lineprof/sample.rb
+++ b/lib/rack/lineprof/sample.rb
@@ -1,12 +1,12 @@
 module Rack
   class Lineprof
-    class Sample < Struct.new :ms, :calls, :line, :code, :level
+    class Sample < Struct.new :ms, :calls, :line, :code, :level, :allocations
 
       def format colorize = true
         formatted = if level == CONTEXT
           sprintf "               | % 3i  %s", line, code
         else
-          sprintf "% 6.1fms %5i | % 3i  %s", ms, calls, line, code
+          sprintf "% 6.1fms %5i | % 3i  %s (%s malloc)", ms, calls, line, code, allocations
         end
 
         return formatted unless colorize

--- a/lib/rack/lineprof/sample.rb
+++ b/lib/rack/lineprof/sample.rb
@@ -4,9 +4,9 @@ module Rack
 
       def format colorize = true
         formatted = if level == CONTEXT
-          sprintf "                          | % 3i  %s", line, code
+          sprintf "                           | % 3i  %s", line, code
         else
-          sprintf "% 6.1fms %5i (%8s) | % 3i  %s", ms, calls, allocations, line, code
+          sprintf "% 9.1fms %5i %8s | % 3i  %s", ms, calls, allocations, line, code
         end
 
         return formatted unless colorize

--- a/lib/rack/lineprof/source.rb
+++ b/lib/rack/lineprof/source.rb
@@ -13,7 +13,13 @@ module Rack
 
         formatted = file_name.sub(Dir.pwd + '/', '') + "\n"
 
+        prev_line = samples.first.line - 1
         samples.each do |sample|
+          if sample.line != prev_line + 1
+            formatted << color.intense_black(' ' * 14 + '.' * 7) + "\n"
+          end
+          prev_line = sample.line
+
           formatted << sample.format
         end
 

--- a/lib/rack/lineprof/source.rb
+++ b/lib/rack/lineprof/source.rb
@@ -35,6 +35,7 @@ module Rack
 
             ms = sample[0] / 1000.0
             calls = sample[2]
+            allocations = sample[3]
 
             abnormal = ms >= thresholds[NOMINAL]
             near_abnormal = (line-context..line+context).any? do |near|
@@ -49,7 +50,7 @@ module Rack
             level = threshold ? threshold.last : CONTEXT
 
             next unless code = source_lines[line - 1]
-            parsed << Sample.new(ms, calls, line, code, level)
+            parsed << Sample.new(ms, calls, line, code, level, allocations)
           end
 
           parsed

--- a/lib/rack/lineprof/source.rb
+++ b/lib/rack/lineprof/source.rb
@@ -13,13 +13,7 @@ module Rack
 
         formatted = file_name.sub(Dir.pwd + '/', '') + "\n"
 
-        prev_line = samples.first.line - 1
         samples.each do |sample|
-          if sample.line != prev_line + 1
-            formatted << color.intense_black(' ' * 14 + '.' * 7) + "\n"
-          end
-          prev_line = sample.line
-
           formatted << sample.format
         end
 


### PR DESCRIPTION
Hello,

This PR adds memory allocations info to be printed for each line.

I wonder if this is a use case that we could support, given that the memory profile is already made available by lineprof.

Also added headers to the top banner to account for the new column.


![image](https://user-images.githubusercontent.com/5464881/192681913-08098294-aa3a-4809-9b7e-0e9e2be05ce9.png)
